### PR TITLE
correct source- and target-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.5.1</version>
                     <configuration>
-                        <source>1.11</source>
-                        <target>1.11</target>
+                        <source>11</source>
+                        <target>11</target>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
Die 1.x war noch bei JDK8 nötig, bei JDK11 muss die 11 aber alleine stehen.